### PR TITLE
blur input elements every time signature pad gets focus

### DIFF
--- a/jquery.signaturepad.js
+++ b/jquery.signaturepad.js
@@ -390,15 +390,14 @@ function SignaturePad (selector, options) {
    * @param {Object} e The event object
    */
   function initDrawEvents (e) {
+    // Closes open keyboards to free up space
+    if(document.activeElement && document.activeElement.nodeName === "INPUT") {
+      $(document.activeElement).blur();
+    }
     if (eventsBound)
       return false
 
     eventsBound = true
-
-    // Closes open keyboards to free up space
-    if( document.activeElement && document.activeElement.nodeName === "INPUT"){
-      $( document.activeElement ).blur();
-    }
     
     if (typeof e.targetTouches !== 'undefined')
       touchable = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signature-pad",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "private": true,
   "license": "BSD-3-CLAUSE",
   "description": "SignaturePad: A jQuery plugin for assisting in the creation of an HTML5 canvas based signature pad. Records the drawn signature in JSON for later regeneration.",


### PR DESCRIPTION
this fixes a problem in which the blur() can only be executed once. The eventsBound is set to true after first execution of initDrawEvents and subsequent initDrawEvents calls which are done when user starts to draw do not blur focus input elements.
